### PR TITLE
Fixed error with scientific notation in RPY

### DIFF
--- a/imgparse/_version.py
+++ b/imgparse/_version.py
@@ -1,3 +1,3 @@
 """Defines package version.  Parsed by setup.py and imported by __init__.py."""
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"

--- a/imgparse/cli.py
+++ b/imgparse/cli.py
@@ -169,6 +169,7 @@ def create_metadata_csv(imagery_dir):  # noqa: D301
     )
 
     for image_path in images:
+        logger.info("Parsing image: %s", image_path)
         exif_data = imgparse.get_exif_data(image_path)
         xmp_data = imgparse.get_xmp_data(image_path)
 

--- a/imgparse/xmp.py
+++ b/imgparse/xmp.py
@@ -41,17 +41,19 @@ class SensorMake(NamedTuple):
 
 
 Sentera = SensorMake(
-    RELATIVE_ALT=re.compile(r'Camera:AboveGroundAltitude="([0-9]+.[0-9]+)"'),
-    ROLL=re.compile(r'Camera:Roll="(-?[0-9]+.[0-9]+)"'),
-    PITCH=re.compile(r'Camera:Pitch="(-?[0-9]+.[0-9]+)"'),
-    YAW=re.compile(r'Camera:Yaw="(-?[0-9]+.[0-9]+)"'),
+    RELATIVE_ALT=re.compile(r'Camera:AboveGroundAltitude="(-?[0-9]+.[0-9]+)"'),
+    ROLL=re.compile(r'Camera:Roll="(-?[0-9]+.[0-9]+(?:E-?[0-9]+)?)"'),
+    PITCH=re.compile(r'Camera:Pitch="(-?[0-9]+.[0-9]+(?:E-?[0-9]+)?)"'),
+    YAW=re.compile(r'Camera:Yaw="(-?[0-9]+.[0-9]+(?:E-?[0-9]+)?)"'),
 )
 
 DJI = SensorMake(
     RELATIVE_ALT=re.compile(r'drone-dji:RelativeAltitude="(-?\+?[0-9]+.[0-9]+)"'),
-    ROLL=re.compile(r'drone-dji:GimbalRollDegree="(-?\+?[0-9]+.[0-9]+)"'),
-    PITCH=re.compile(r'drone-dji:GimbalPitchDegree="(-?\+?[0-9]+.[0-9]+)"'),
-    YAW=re.compile(r'drone-dji:GimbalYawDegree="(-?\+?[0-9]+.[0-9]+)"'),
+    ROLL=re.compile(r'drone-dji:GimbalRollDegree="(-?\+?[0-9]+.[0-9]+(?:E-?[0-9]+)?)"'),
+    PITCH=re.compile(
+        r'drone-dji:GimbalPitchDegree="(-?\+?[0-9]+.[0-9]+(?:E-?[0-9]+)?)"'
+    ),
+    YAW=re.compile(r'drone-dji:GimbalYawDegree="(-?\+?[0-9]+.[0-9]+(?:E-?[0-9]+)?)"'),
 )
 
 


### PR DESCRIPTION
# Fixed error with scientific notation in RPY
## What?
XMP regex parsing was failing to find roll, pitch, yaw if they were in scientific notation.  This fixes the problem.
- [x] Merged latest master
- [x] Updated version number
- [x] All private git packages are at their newest version in both *Pipfile* and *environment.yml*
- [x] All git package version numbers match between *Pipfile* and *environment.yml*
## Breaking Changes
No