### PR TITLE
Output focal length in metadata csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ analytics-metadata.csv
 .coverage
 empty_dir/
 htmlcov/
+.DS_Store

--- a/imgparse/_version.py
+++ b/imgparse/_version.py
@@ -1,3 +1,3 @@
 """Defines package version.  Parsed by setup.py and imported by __init__.py."""
 
-__version__ = "1.9.4"
+__version__ = "1.10.0"

--- a/imgparse/_version.py
+++ b/imgparse/_version.py
@@ -1,3 +1,3 @@
 """Defines package version.  Parsed by setup.py and imported by __init__.py."""
 
-__version__ = "1.9.3"
+__version__ = "1.9.4"

--- a/imgparse/cli.py
+++ b/imgparse/cli.py
@@ -198,13 +198,13 @@ def create_metadata_csv(imagery_dir):  # noqa: D301
     data_frame = pandas.DataFrame(
         columns=[
             "File Name",
-            "Lat (decimal degrees)",
-            "Lon (decimal degrees)",
-            "Alt (meters MSL)",
-            "Roll (decimal degrees)",
-            "Pitch (decimal degrees)",
-            "Yaw (decimal degrees)",
-            "Relative Altitude",
+            "Lat (degrees)",
+            "Lon (degrees)",
+            "ASL Alt (meters)",
+            "Roll (degrees)",
+            "Pitch (degrees)",
+            "Yaw (degrees)",
+            "AGL Alt (meters)",
             "Focal Length (pixels)",
         ]
     )

--- a/imgparse/cli.py
+++ b/imgparse/cli.py
@@ -205,6 +205,7 @@ def create_metadata_csv(imagery_dir):  # noqa: D301
             "Pitch (decimal degrees)",
             "Yaw (decimal degrees)",
             "Relative Altitude",
+            "Focal Length (pixels)",
         ]
     )
 
@@ -212,6 +213,7 @@ def create_metadata_csv(imagery_dir):  # noqa: D301
         logger.info("Parsing image: %s", image_path)
         exif_data = imgparse.get_exif_data(image_path)
         xmp_data = imgparse.get_xmp_data(image_path)
+        fl, pp = imgparse.get_camera_params(image_path)
 
         data_frame.loc[len(data_frame)] = [
             os.path.split(image_path)[1],
@@ -219,6 +221,7 @@ def create_metadata_csv(imagery_dir):  # noqa: D301
             imgparse.get_altitude_msl(image_path, exif_data),
             *imgparse.get_roll_pitch_yaw(image_path, exif_data, xmp_data),
             imgparse.get_relative_altitude(image_path, exif_data, xmp_data),
+            fl / pp,
         ]
 
     metadata_csv = os.path.join(imagery_dir, "analytics-metadata.csv")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imgparse"
-version = "1.9.4"
+version = "1.10.0"
 description = "Python image-metadata-parser utilities"
 authors = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imgparse"
-version = "1.9.3"
+version = "1.9.4"
 description = "Python image-metadata-parser utilities"
 authors = []
 


### PR DESCRIPTION
# Output focal length in metadata csv
## What?
Output focal length (in pixels) in the metadata csv created by `create_metadata_csv()` in a new column named "Focal Length (pixels)".  Also renamed created metadata csv columns to more sane names.
## Why?
This is needed by updates to quicktile to use a metadata csv to quicktile pngs.  Since we can't read the focal length from the PNG exif, we need another way to pass this information into quicktile.  Outputting it as part of the created metadata csv is a good place to put it.
## PR Checklist
- [x] Merged latest master
- [x] Updated version number
- [x] Version numbers match between package ``__version__`` and *pyproject.toml*
- [ ] All private git packages are at their newest version in both *pyproject.toml* and *environment.yml*
- [ ] All git package version numbers match between *pyproject.toml* and *environment.yml*
## Breaking Changes
Kinda.  Anything relying on the column names in the created metadata csv will have to update.  But since we aren't breaking the api at all, I'm just bumping the minor version.