### PR TITLE
Change output metadata column names back to match pix4d.csv

### DIFF
--- a/imgparse/_version.py
+++ b/imgparse/_version.py
@@ -1,3 +1,3 @@
 """Defines package version.  Parsed by setup.py and imported by __init__.py."""
 
-__version__ = "1.10.0"
+__version__ = "1.10.1"

--- a/imgparse/cli.py
+++ b/imgparse/cli.py
@@ -198,13 +198,13 @@ def create_metadata_csv(imagery_dir):  # noqa: D301
     data_frame = pandas.DataFrame(
         columns=[
             "File Name",
-            "Lat (degrees)",
-            "Lon (degrees)",
-            "ASL Alt (meters)",
-            "Roll (degrees)",
-            "Pitch (degrees)",
-            "Yaw (degrees)",
-            "AGL Alt (meters)",
+            "Lat (decimal degrees)",
+            "Lon (decimal degrees)",
+            "Alt (meters MSL)",
+            "Roll (decimal degrees)",
+            "Pitch (decimal degrees)",
+            "Yaw (decimal degrees)",
+            "Alt (meters AGL)",
             "Focal Length (pixels)",
         ]
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imgparse"
-version = "1.10.0"
+version = "1.10.1"
 description = "Python image-metadata-parser utilities"
 authors = []
 


### PR DESCRIPTION
# Undo last changes that renamed output metadata csv column names
## What?
Undo last changes that renamed output metadata csv column names.
## Why?
The previous column names matched what was output by pix4d.  The new ones don't.  Even though I prefer the new names, I think it is best to match what pix4d outputs so the GIS team doesn't have to remember what columns to rename when they want to run a quicktile with pix4d output.
## PR Checklist
- [x] Merged latest master
- [x] Updated version number
- [x] Version numbers match between package ``__version__`` and *pyproject.toml*
- [ ] All private git packages are at their newest version in both *pyproject.toml* and *environment.yml*
- [ ] All git package version numbers match between *pyproject.toml* and *environment.yml*
## Breaking Changes
No.