### PR TITLE
Update ils function to optionally get clear band

### DIFF
--- a/imgparse/_version.py
+++ b/imgparse/_version.py
@@ -1,3 +1,3 @@
 """Defines package version.  Parsed by setup.py and imported by __init__.py."""
 
-__version__ = "1.10.2"
+__version__ = "1.10.3"

--- a/imgparse/imgparse.py
+++ b/imgparse/imgparse.py
@@ -80,7 +80,7 @@ def get_firmware_version(image_path=None, exif_data=None):
 @get_if_needed("xmp_data", getter=get_xmp_data, getter_args=["image_path"])
 def get_ils(image_path=None, xmp_data=None, use_clear_channel=False):
     """
-    Get the ILS value of an image taken with a Sentera 6X sensor with an ILS module.
+    Get the ILS value of an image captured by a sensor with an ILS module.
 
     This function will always raise an exception if called on XMP data from any sensor other than a 6X with
     an included ILS module.

--- a/imgparse/imgparse.py
+++ b/imgparse/imgparse.py
@@ -78,7 +78,7 @@ def get_firmware_version(image_path=None, exif_data=None):
 
 
 @get_if_needed("xmp_data", getter=get_xmp_data, getter_args=["image_path"])
-def get_ils(image_path=None, xmp_data=None):
+def get_ils(image_path=None, xmp_data=None, use_clear_channel=False):
     """
     Get the ILS value of an image taken with a Sentera 6X sensor with an ILS module.
 
@@ -87,11 +87,15 @@ def get_ils(image_path=None, xmp_data=None):
 
     :param image_path: the full path to the image (optional if `xmp_data` provided)
     :param xmp_data: the XMP data of image, as a string dump of the original XML (optional to speed up processing)
+    :param use_clear_channel: if true, refer to the ILS clear channel value instead of the default
     :return: **ils** -- ILS value of image, as a floating point number
     :raises: ParsingError
     """
     try:
-        ils = float(xmp.find(xmp_data, [xmp.ILS, xmp.SEQ]))
+        if use_clear_channel:
+            ils = float(xmp.find(xmp_data, [xmp.ILS_CLEAR]))
+        else:
+            ils = float(xmp.find(xmp_data, [xmp.ILS, xmp.SEQ]))
     except XMPTagNotFoundError:
         logger.error("Couldn't parse ILS value")
         raise ParsingError(

--- a/imgparse/xmp.py
+++ b/imgparse/xmp.py
@@ -18,6 +18,7 @@ SEQ = re.compile(r"(?: *|\t)<rdf:li>(.*)</rdf:li>")
 
 # Sentera-exclusive patterns:
 ILS = re.compile(r"<Camera:SunSensor>.*</Camera:SunSensor>", re.DOTALL)
+ILS_CLEAR = re.compile(r'ILS:Clear="(.*)"')
 
 
 class XMPTagNotFoundError(Exception):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imgparse"
-version = "1.10.2"
+version = "1.10.3"
 description = "Python image-metadata-parser utilities"
 authors = []
 


### PR DESCRIPTION
# Update ils function to optionally get clear band
## What?
Update ils function to optionally get clear band
## Why?
For D4K sensors, it's recommended to use the ILS clear channel for normalization instead of the default value.
## PR Checklist
- [X] Merged latest master
- [X] Updated version number
- [X] Version numbers match between package ``__version__`` and *pyproject.toml*
- [ ] All private git packages are at their newest version in both *pyproject.toml* and *environment.yml*
- [ ] All git package version numbers match between *pyproject.toml* and *environment.yml*
## Breaking Changes
None. Changes should be unnoticeable for people not using new optional argument.