### PR TITLE
Add function to get XMP wavelength data

### DIFF
--- a/imgparse/__init__.py
+++ b/imgparse/__init__.py
@@ -38,6 +38,7 @@ from imgparse.imgparse import (
     get_relative_altitude,
     get_roll_pitch_yaw,
     get_timestamp,
+    get_wavelength_data,
     parse_session_alt,
 )
 from imgparse.metadata import get_metadata
@@ -61,6 +62,7 @@ __all__ = [
     "get_timestamp",
     "get_autoexposure",
     "get_firmware_version",
+    "get_wavelength_data",
     "get_metadata",
     "ParsingError",
 ]

--- a/imgparse/_version.py
+++ b/imgparse/_version.py
@@ -1,3 +1,3 @@
 """Defines package version.  Parsed by setup.py and imported by __init__.py."""
 
-__version__ = "1.10.4"
+__version__ = "1.10.5"

--- a/imgparse/cli.py
+++ b/imgparse/cli.py
@@ -158,6 +158,19 @@ def get_firmware_version(image_path):
 
 @cli.command()
 @click.argument("image_path", required=True)
+def get_wavelength_data(image_path):
+    """Parse wavelength data from metadata."""
+    data = imgparse.get_wavelength_data(image_path)
+    print("Central Wavelength:")
+    for w in data[0]:
+        print(f"  {w}")
+    print("WavelengthFWHM:")
+    for f in data[1]:
+        print(f"  {f}")
+
+
+@cli.command()
+@click.argument("image_path", required=True)
 @click.argument("metadata", required=True, nargs=-1, type=ClickMetadata())
 def get_metadata(image_path, metadata):
     """Get a variable number of supported metadata."""

--- a/imgparse/imgparse.py
+++ b/imgparse/imgparse.py
@@ -489,3 +489,24 @@ def get_gsd(image_path, exif_data=None, xmp_data=None, corrected_alt=None):
         raise ValueError("Parsed gsd is less than or equal to 0")
 
     return gsd
+
+
+@get_if_needed("xmp_data", getter=get_xmp_data, getter_args=["image_path"])
+def get_wavelength_data(image_path=None, xmp_data=None):
+    """
+    Get the ILS value of an image captured by a sensor with an ILS module.
+
+    :param image_path: the full path to the image (optional if `xmp_data` provided)
+    :param xmp_data: the XMP data of image, as a string dump of the original XML (optional to speed up processing)
+    :param use_clear_channel: if true, refer to the ILS clear channel value instead of the default
+    :return: **ils** -- ILS value of image, as a floating point number
+    :raises: ParsingError
+    """
+    try:
+        central_wavelength = xmp.find(xmp_data, [xmp.CNTWV, xmp.SEQ])
+        wavelength_fwhm = xmp.find(xmp_data, [xmp.FWHM, xmp.SEQ])
+    except XMPTagNotFoundError:
+        logger.error("Couldn't parse wavelength data")
+        raise ParsingError("Couldn't parse wavelength data.")
+
+    return central_wavelength, wavelength_fwhm

--- a/imgparse/imgparse.py
+++ b/imgparse/imgparse.py
@@ -503,8 +503,8 @@ def get_wavelength_data(image_path=None, xmp_data=None):
     :raises: ParsingError
     """
     try:
-        central_wavelength = xmp.find(xmp_data, [xmp.CNTWV, xmp.SEQ])
-        wavelength_fwhm = xmp.find(xmp_data, [xmp.FWHM, xmp.SEQ])
+        central_wavelength = xmp.find_multiple(xmp_data, [xmp.CNTWV, xmp.SEQ])
+        wavelength_fwhm = xmp.find_multiple(xmp_data, [xmp.FWHM, xmp.SEQ])
     except XMPTagNotFoundError:
         logger.error("Couldn't parse wavelength data")
         raise ParsingError("Couldn't parse wavelength data.")

--- a/imgparse/metadata.py
+++ b/imgparse/metadata.py
@@ -31,6 +31,9 @@ MAKE_AND_MODEL = Metadata(name="(Make, Model)", method=imgparse.get_make_and_mod
 DIMENSIONS = Metadata(name="Dimensions", method=imgparse.get_dimensions)
 GSD = Metadata(name="Gsd (m)", method=imgparse.get_gsd)
 FIRMWARE = Metadata(name="Firmware version", method=imgparse.get_firmware_version)
+WAVELENGTH = Metadata(
+    name="Central Wavelength, WavelengthFWHM", method=imgparse.get_wavelength_data
+)
 
 
 def get_metadata(image_path: str, *metadata: Metadata):

--- a/imgparse/xmp.py
+++ b/imgparse/xmp.py
@@ -118,6 +118,8 @@ def find(xmp_data: str, patterns: List[re.Pattern]) -> str:
         # If called on a string but no match was found, findall() returns an empty list:
         if match:
             # Returns the whole match
+            print(match)
+            print(match[0])
             return match[0]
         else:
             raise XMPTagNotFoundError(

--- a/imgparse/xmp.py
+++ b/imgparse/xmp.py
@@ -120,7 +120,7 @@ def find(xmp_data: str, patterns: List[re.Pattern]) -> str:
             # Returns the whole match
             print(match)
             print(match[0])
-            return match[0]
+            return match
         else:
             raise XMPTagNotFoundError(
                 "A tag pattern did not match with the XMP string. The tag may not exist."

--- a/imgparse/xmp.py
+++ b/imgparse/xmp.py
@@ -102,13 +102,41 @@ def find(xmp_data: str, patterns: List[re.Pattern]) -> str:
     This function recurses over the list of patterns, applying each one to the remaining matching XMP string
     and passing the subsequent matching string to the next iteration.
 
-    If multiple capture groups are in a passed pattern, that pattern must be the last pattern in the list --
-    in this situation, a tuple will be returned with each matched group. This can be useful when matching tags
-    in a "<rdf:Seq>".
+    Only the first matching occurence is passed for each step.
 
     :param xmp_data: XMP string to be parsed
     :param patterns: List of patterns to be applied to the XMP string
     :return: **match** -- Matched string (if all matches are successful)
+    :raises: XMPTagNotFoundError
+    """
+
+    def _find_inner(partial_xmp: str, pattern: re.Pattern) -> str:
+        match = pattern.findall(partial_xmp)
+
+        # If called on a string but no match was found, findall() returns an empty list:
+        if match:
+            # Returns the whole match
+            return match[0]
+        else:
+            raise XMPTagNotFoundError(
+                "A tag pattern did not match with the XMP string. The tag may not exist."
+            )
+
+    return reduce(_find_inner, patterns, xmp_data)
+
+
+def find_multiple(xmp_data: str, patterns: List[re.Pattern]) -> List[str]:
+    """
+    Sequentially apply a list of patterns to the xmp data to parse a value of interest.
+
+    This function recurses over the list of patterns, applying each one to the remaining matching XMP strings
+    and passing the subsequent matching strings to the next iteration.
+
+    All matching occurences are returned in a list, even if there's only one.
+
+    :param xmp_data: XMP string to be parsed
+    :param patterns: List of patterns to be applied to the XMP string
+    :return: **match** -- Matched strings (if all matches are successful)
     :raises: XMPTagNotFoundError
     """
 

--- a/imgparse/xmp.py
+++ b/imgparse/xmp.py
@@ -18,6 +18,10 @@ SEQ = re.compile(r"(?: *|\t)<rdf:li>(.*)</rdf:li>")
 
 # Sentera-exclusive patterns:
 ILS = re.compile(r"<Camera:SunSensor>.*</Camera:SunSensor>", re.DOTALL)
+CNTWV = re.compile(
+    r"<Camera:CentralWavelength>.*</Camera:CentralWavelength>", re.DOTALL
+)
+FWHM = re.compile(r"<Camera:WavelengthFWHM>.*</Camera:WavelengthFWHM>", re.DOTALL)
 ILS_CLEAR = re.compile(r'ILS:Clear="(.*)"')
 
 

--- a/imgparse/xmp.py
+++ b/imgparse/xmp.py
@@ -112,18 +112,16 @@ def find(xmp_data: str, patterns: List[re.Pattern]) -> str:
     :raises: XMPTagNotFoundError
     """
 
-    def _find_inner(partial_xmp: str, pattern: re.Pattern) -> str:
-        match = pattern.findall(partial_xmp)
+    def _find_inner(partial_xmp: List[str], pattern: re.Pattern) -> List[str]:
+        matches = []
+        for s in partial_xmp:
+            matches += pattern.findall(s)
 
         # If called on a string but no match was found, findall() returns an empty list:
-        if match:
-            # Returns the whole match
-            print(match)
-            print(match[0])
-            return match
-        else:
+        if not matches:
             raise XMPTagNotFoundError(
                 "A tag pattern did not match with the XMP string. The tag may not exist."
             )
+        return matches
 
-    return reduce(_find_inner, patterns, xmp_data)
+    return reduce(_find_inner, patterns, [xmp_data])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imgparse"
-version = "1.10.4"
+version = "1.10.5"
 description = "Python image-metadata-parser utilities"
 authors = []
 


### PR DESCRIPTION
# Add function to get XMP wavelength data
## What?
Add function to get XMP wavelength data. Also add generic function to find multiple xmp pattern matches.
## Why?
Extracting central wavelength and wfhm (for multiple channels, if present) is necessary for determining reflectance coefficient during radiometric correction.
## PR Checklist
- [X] Merged latest master
- [X] Updated version number
- [X] Version numbers match between package ``__version__`` and *pyproject.toml*
- [ ] All private git packages are at their newest version in both *pyproject.toml* and *environment.yml*
- [ ] All git package version numbers match between *pyproject.toml* and *environment.yml*
## Breaking Changes
None