### PR TITLE
Update Sentera XMP regular expressions

### DIFF
--- a/imgparse/_version.py
+++ b/imgparse/_version.py
@@ -1,3 +1,3 @@
 """Defines package version.  Parsed by setup.py and imported by __init__.py."""
 
-__version__ = "1.10.7"
+__version__ = "1.10.8"

--- a/imgparse/xmp.py
+++ b/imgparse/xmp.py
@@ -47,10 +47,10 @@ class SensorMake(NamedTuple):
 
 
 Sentera = SensorMake(
-    RELATIVE_ALT=re.compile(r"Camera:AboveGroundAltitude[\D]*(-?[0-9]+.[0-9]+)"),
-    ROLL=re.compile(r"Camera:Roll[\D]*(-?[0-9]+.[0-9]+(?:E-?[0-9]+)?)"),
-    PITCH=re.compile(r"Camera:Pitch[\D]*(-?[0-9]+.[0-9]+(?:E-?[0-9]+)?)"),
-    YAW=re.compile(r"Camera:Yaw[\D]*(-?[0-9]+.[0-9]+(?:E-?[0-9]+)?)"),
+    RELATIVE_ALT=re.compile(r"Camera:AboveGroundAltitude[^-\d]*(-?[0-9]+.[0-9]+)"),
+    ROLL=re.compile(r"Camera:Roll[^-\d]*(-?[0-9]+.[0-9]+(?:E-?[0-9]+)?)"),
+    PITCH=re.compile(r"Camera:Pitch[^-\d]*(-?[0-9]+.[0-9]+(?:E-?[0-9]+)?)"),
+    YAW=re.compile(r"Camera:Yaw[^-\d]*(-?[0-9]+.[0-9]+(?:E-?[0-9]+)?)"),
 )
 
 DJI = SensorMake(

--- a/imgparse/xmp.py
+++ b/imgparse/xmp.py
@@ -47,10 +47,10 @@ class SensorMake(NamedTuple):
 
 
 Sentera = SensorMake(
-    RELATIVE_ALT=re.compile(r'Camera:AboveGroundAltitude="(-?[0-9]+.[0-9]+)"'),
-    ROLL=re.compile(r'Camera:Roll="(-?[0-9]+.[0-9]+(?:E-?[0-9]+)?)"'),
-    PITCH=re.compile(r'Camera:Pitch="(-?[0-9]+.[0-9]+(?:E-?[0-9]+)?)"'),
-    YAW=re.compile(r'Camera:Yaw="(-?[0-9]+.[0-9]+(?:E-?[0-9]+)?)"'),
+    RELATIVE_ALT=re.compile(r"Camera:AboveGroundAltitude[\D]*(-?[0-9]+.[0-9]+)"),
+    ROLL=re.compile(r"Camera:Roll[\D]*(-?[0-9]+.[0-9]+(?:E-?[0-9]+)?)"),
+    PITCH=re.compile(r"Camera:Pitch[\D]*(-?[0-9]+.[0-9]+(?:E-?[0-9]+)?)"),
+    YAW=re.compile(r"Camera:Yaw[\D]*(-?[0-9]+.[0-9]+(?:E-?[0-9]+)?)"),
 )
 
 DJI = SensorMake(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imgparse"
-version = "1.10.7"
+version = "1.10.8"
 description = "Python image-metadata-parser utilities"
 authors = []
 


### PR DESCRIPTION
# Update Sentera XMP regular expressions
## What?
Update XMP regular expressions for Sentera sensors to accept any number of non-digit, non-"-" characters between Pitch, Roll, Yaw, and Relative Altitude search terms and their float values.
## Why?
XMP formatting was changed at some point for the 6x. This update allows Pitch/Roll/Yaw/Relative Altitude to be extracted for both formats.
## PR Checklist
- [X] Merged latest master
- [X] Updated version number
- [X] Version numbers match between package ``__version__`` and *pyproject.toml*
- [ ] All private git packages are at their newest version in both *pyproject.toml* and *environment.yml*
- [ ] All git package version numbers match between *pyproject.toml* and *environment.yml*
## Breaking Changes
