### PR TITLE
get_wavelength_data() Quick fix

### DIFF
--- a/imgparse/_version.py
+++ b/imgparse/_version.py
@@ -1,3 +1,3 @@
 """Defines package version.  Parsed by setup.py and imported by __init__.py."""
 
-__version__ = "1.14.0"
+__version__ = "1.14.1"

--- a/imgparse/imgparse.py
+++ b/imgparse/imgparse.py
@@ -649,11 +649,11 @@ def get_wavelength_data(image_path, exif_data=None, xmp_data=None):
         make, model = get_make_and_model(image_path, exif_data)
         xmp_tags = xmp.get_tags(make)
         try:
-            central_wavelength = parse_seq(xmp_data[xmp_tags.WAVELENGTH_CENTRAL], int)
-            wavelength_fwhm = parse_seq(xmp_data[xmp_tags.WAVELENGTH_FWHM], int)
+            central_wavelength = parse_seq(xmp_data[xmp_tags.WAVELENGTH_CENTRAL], float)
+            wavelength_fwhm = parse_seq(xmp_data[xmp_tags.WAVELENGTH_FWHM], float)
         except TypeError:
-            central_wavelength = [int(xmp_data[xmp_tags.WAVELENGTH_CENTRAL])]
-            wavelength_fwhm = [int(xmp_data[xmp_tags.WAVELENGTH_FWHM])]
+            central_wavelength = [float(xmp_data[xmp_tags.WAVELENGTH_CENTRAL])]
+            wavelength_fwhm = [float(xmp_data[xmp_tags.WAVELENGTH_FWHM])]
 
         return central_wavelength, wavelength_fwhm
     except KeyError:

--- a/imgparse/imgparse.py
+++ b/imgparse/imgparse.py
@@ -649,8 +649,8 @@ def get_wavelength_data(image_path, exif_data=None, xmp_data=None):
         make, model = get_make_and_model(image_path, exif_data)
         xmp_tags = xmp.get_tags(make)
         try:
-            central_wavelength = parse_seq(xmp_data[xmp_tags.WAVELENGTH_CENTRAL], float)
-            wavelength_fwhm = parse_seq(xmp_data[xmp_tags.WAVELENGTH_FWHM], float)
+            central_wavelength = parse_seq(xmp_data[xmp_tags.WAVELENGTH_CENTRAL], int)
+            wavelength_fwhm = parse_seq(xmp_data[xmp_tags.WAVELENGTH_FWHM], int)
         except TypeError:
             central_wavelength = [float(xmp_data[xmp_tags.WAVELENGTH_CENTRAL])]
             wavelength_fwhm = [float(xmp_data[xmp_tags.WAVELENGTH_FWHM])]

--- a/imgparse/imgparse.py
+++ b/imgparse/imgparse.py
@@ -649,8 +649,8 @@ def get_wavelength_data(image_path, exif_data=None, xmp_data=None):
         make, model = get_make_and_model(image_path, exif_data)
         xmp_tags = xmp.get_tags(make)
         try:
-            central_wavelength = parse_seq(xmp_data[xmp_tags.WAVELENGTH_CENTRAL], int)
-            wavelength_fwhm = parse_seq(xmp_data[xmp_tags.WAVELENGTH_FWHM], int)
+            central_wavelength = parse_seq(xmp_data[xmp_tags.WAVELENGTH_CENTRAL], float)
+            wavelength_fwhm = parse_seq(xmp_data[xmp_tags.WAVELENGTH_FWHM], float)
         except TypeError:
             central_wavelength = [float(xmp_data[xmp_tags.WAVELENGTH_CENTRAL])]
             wavelength_fwhm = [float(xmp_data[xmp_tags.WAVELENGTH_FWHM])]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imgparse"
-version = "1.14.0"
+version = "1.14.1"
 description = "Python image-metadata-parser utilities"
 authors = []
 


### PR DESCRIPTION
# get_wavelength_data() Quick fix
## What?
Change central wavlength from int to float.
## Why?
The Micasense panchromatic band has a central wavelength of 634.5.  get_wavelength_data() fails when converting a string float value to an integer.
## PR Checklist
- [ ] Merged latest master
- [x] Updated version number
- [x] Version numbers match between package ``_version.py`` and *pyproject.toml*
## Breaking Changes
