### PR TITLE
Read max exif header from s3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python: 3.10
 dist: focal
 
 install:
-  - pip install poetry
+  - curl -sSL https://install.python-poetry.org | python3 -
   - poetry install -E timestamps
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: focal
 
 install:
   - curl -sSL https://install.python-poetry.org | python3 -
+  - python3 -m keyring --disable
   - poetry install -E timestamps
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ dist: focal
 
 install:
   - curl -sSL https://install.python-poetry.org | python3 -
-  - python3 -m keyring --disable
-  - poetry install -E timestamps
+  # Hack for strange error that appears will be fixed in poetry v1.7
+  # https://github.com/python-poetry/poetry/issues/1917
+  - PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring poetry install -E timestamps
 
 script:
   - poetry run pre-commit run --all-files

--- a/imgparse/_version.py
+++ b/imgparse/_version.py
@@ -1,3 +1,3 @@
 """Defines package version.  Parsed by setup.py and imported by __init__.py."""
 
-__version__ = "1.15.0"
+__version__ = "1.15.1"

--- a/imgparse/getters.py
+++ b/imgparse/getters.py
@@ -65,18 +65,9 @@ def read_exif_header_from_s3(image_path):
 
     bucket, key = image_path[5:].split("/", 1)
     obj = boto3.resource("s3").Object(bucket, key)
-    # Read the first 12 bytes of the image to parse the header size
-    exif_start = obj.get(Range="bytes=0-11")["Body"].read().hex()
-    # Check the header matches the format expected
-    # See here for more info: https://www.media.mit.edu/pia/Research/deepview/exif.html
-    if exif_start[:8] == "ffd8ffe1" and exif_start[12:] == "457869660000":
-        size = int(exif_start[8:12], 16)
-    else:
-        logger.warning("S3 file doesn't match expected exif header format")
-        size = 65536
 
     # Read the entire exif header for the image and return it to be parsed by exifread
-    return BytesIO(obj.get(Range=f"bytes=0-{size}")["Body"].read())
+    return BytesIO(obj.get(Range="bytes=0-65536")["Body"].read())
 
 
 @memoize

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imgparse"
-version = "1.15.0"
+version = "1.15.1"
 description = "Python image-metadata-parser utilities"
 authors = []
 


### PR DESCRIPTION
# Read max exif header from s3
## What?
Previously I was trying to minimize the amount of data we had to read from s3 by first reading the first 12 bytes of the image to parse the size of the exif header, then reading the exact amount of bytes to get the entire header. However it seems this wasn't quite enough data, as we were getting errors for some images when parsing their exif from s3. It seems adding an extra 4 bytes was enough to fix it, but I did some speed tests and reading the maximum size of the exif header (65536 bytes) seems to be very close to the same speed as making two different, smaller reads. So I decided to just hard code it to the maximum size and leave it at that.
## Why?
Fixes an error with auto-rejection in the mfstand tool
## PR Checklist
- [x] Merged latest master
- [x] Updated version number
- [x] Version numbers match between package ``_version.py`` and *pyproject.toml*
## Breaking Changes
