### PR TITLE
FIX: Principal point returns pixels instead of mm

### DIFF
--- a/imgparse/_version.py
+++ b/imgparse/_version.py
@@ -1,3 +1,3 @@
 """Defines package version.  Parsed by setup.py and imported by __init__.py."""
 
-__version__ = "1.17.0"
+__version__ = "1.17.1"

--- a/imgparse/imgparse.py
+++ b/imgparse/imgparse.py
@@ -14,7 +14,7 @@ from imgparse.exceptions import ParsingError, TerrainAPIError
 from imgparse.getters import get_exif_data, get_xmp_data
 from imgparse.pixel_pitches import PIXEL_PITCHES
 from imgparse.rotations import apply_rotational_offset
-from imgparse.types import Coords, Dimensions, Euler, PixelCoords, Version
+from imgparse.types import Coords, Dimensions, Euler, SensorCoords, Version
 from imgparse.util import convert_to_degrees, convert_to_float, parse_seq
 
 logger = logging.getLogger(__name__)
@@ -226,19 +226,19 @@ def get_principal_point(
     xmp_data=None,
 ):
     """
-    Get the principal point (x, y) of the sensor that took the image.
+    Get the principal point (x, y) in mm of the sensor that took the image.
 
     :param image_path: the full path to the image
     :param exif_data: used internally for memoization. Not necessary to supply.
     :param xmp_data: used internally for memoization. Not necessary to supply.
-    :return: **principal_point** - a tuple of pixel coordinates of the principal point
+    :return: **principal_point** - a tuple of mm coordinates of the principal point
     :raises: ParsingError
     """
     try:
         make, _ = get_make_and_model(image_path, exif_data)
         xmp_tags = xmp.get_tags(make)
         pt = list(map(float, str(xmp_data[xmp_tags.PRINCIPAL_POINT]).split(",")))
-        return PixelCoords(x=pt[0], y=pt[1])
+        return SensorCoords(x=pt[0], y=pt[1])
     except (KeyError, ValueError):
         raise ParsingError(
             "Couldn't find the principal point tag. Sensor might not be supported"

--- a/imgparse/imgparse.py
+++ b/imgparse/imgparse.py
@@ -226,12 +226,12 @@ def get_principal_point(
     xmp_data=None,
 ):
     """
-    Get the principal point (x, y) in mm of the sensor that took the image.
+    Get the principal point (x, y) in pixels of the sensor that took the image.
 
     :param image_path: the full path to the image
     :param exif_data: used internally for memoization. Not necessary to supply.
     :param xmp_data: used internally for memoization. Not necessary to supply.
-    :return: **principal_point** - a tuple of mm coordinates of the principal point
+    :return: **principal_point** - a tuple of pixel coordinates of the principal point
     :raises: ParsingError
     """
     try:

--- a/imgparse/types.py
+++ b/imgparse/types.py
@@ -5,6 +5,6 @@ from collections import namedtuple
 Quaternion = namedtuple("Quaternion", "q0 q1 q2 q3")
 Euler = namedtuple("Euler", "roll pitch yaw")
 Coords = namedtuple("Coords", "lat lon")
-PixelCoords = namedtuple("PixelCoords", "x y")
+SensorCoords = namedtuple("SensorCoords", "x y")
 Dimensions = namedtuple("Dimensions", "height width")
 Version = namedtuple("Version", "major minor patch")

--- a/imgparse/types.py
+++ b/imgparse/types.py
@@ -5,6 +5,6 @@ from collections import namedtuple
 Quaternion = namedtuple("Quaternion", "q0 q1 q2 q3")
 Euler = namedtuple("Euler", "roll pitch yaw")
 Coords = namedtuple("Coords", "lat lon")
-SensorCoords = namedtuple("SensorCoords", "x y")
+PixelCoords = namedtuple("PixelCoords", "x y")
 Dimensions = namedtuple("Dimensions", "height width")
 Version = namedtuple("Version", "major minor patch")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imgparse"
-version = "1.17.0"
+version = "1.17.1"
 description = "Python image-metadata-parser utilities"
 authors = []
 

--- a/tests/test_imgparse.py
+++ b/tests/test_imgparse.py
@@ -332,7 +332,12 @@ def test_get_dimensions_dji(dji_image_data):
 
 def test_get_principal_point_65r(sentera_65r_image_data):
     x, y = imgparse.get_principal_point(sentera_65r_image_data[0])
-    assert [x, y] == [14.916, 11.14]
+    height, width = imgparse.get_dimensions(sentera_65r_image_data[0])
+
+    known_x_px_offset = -10.75  # checked with metashape camera calibration profile
+    known_y_px_offset = -18.75
+
+    assert [x, y] == [width / 2 + known_x_px_offset, height / 2 + known_y_px_offset]
 
 
 def test_get_distortion_params_65r(sentera_65r_image_data):


### PR DESCRIPTION
# Fix incorrect language and type name regarding principal point coords
## What?
- Convert standard `xmp:Camera:PrincipalPoint` units to pixels before returning
## Why?
- I was wrong about the units and the convention and got lucky with visual tests.
## PR Checklist
- [x] Merged latest master
- [x] Updated version number
- [x] Version numbers match between package ``_version.py`` and *pyproject.toml*
## Breaking Changes
None.