### PR TITLE
[WS] Add Serial Number Support

### DIFF
--- a/imgparse/__init__.py
+++ b/imgparse/__init__.py
@@ -29,6 +29,7 @@ from imgparse.imgparse import (
     get_principal_point,
     get_relative_altitude,
     get_roll_pitch_yaw,
+    get_serial_number,
     get_timestamp,
     get_wavelength_data,
     parse_session_alt,
@@ -62,6 +63,7 @@ __all__ = [
     "get_bandnames",
     "get_ils",
     "get_home_point",
+    "get_serial_number",
     "TerrainAPIError",
     "get_lens_model",
 ]

--- a/imgparse/_version.py
+++ b/imgparse/_version.py
@@ -1,3 +1,3 @@
 """Defines package version.  Parsed by setup.py and imported by __init__.py."""
 
-__version__ = "1.17.2"
+__version__ = "1.18.0"

--- a/imgparse/imgparse.py
+++ b/imgparse/imgparse.py
@@ -72,14 +72,13 @@ def get_firmware_version(image_path, exif_data=None):
 @get_if_needed("exif_data", getter=get_exif_data, getter_args=["image_path"])
 def get_serial_number(image_path, exif_data=None):
     """
-    Get the firmware version of the sensor.
+    Get the serial number of the sensor.
 
-    Expects camera firmware version to be in semver format (i.e. MAJOR.MINOR.PATCH), with an optional 'v'
-    at the beginning.
+    Expects serial number to be parsable as an integer.
 
     :param image_path: the full path to the image
     :param exif_data: used internally for memoization. Not necessary to supply.
-    :return: **major**, **minor**, **patch** - sensor software version
+    :return: **serial_no** - sensor serial version
     :raises: ParsingError
     """
     try:

--- a/imgparse/imgparse.py
+++ b/imgparse/imgparse.py
@@ -70,6 +70,29 @@ def get_firmware_version(image_path, exif_data=None):
 
 
 @get_if_needed("exif_data", getter=get_exif_data, getter_args=["image_path"])
+def get_serial_number(image_path, exif_data=None):
+    """
+    Get the firmware version of the sensor.
+
+    Expects camera firmware version to be in semver format (i.e. MAJOR.MINOR.PATCH), with an optional 'v'
+    at the beginning.
+
+    :param image_path: the full path to the image
+    :param exif_data: used internally for memoization. Not necessary to supply.
+    :return: **major**, **minor**, **patch** - sensor software version
+    :raises: ParsingError
+    """
+    try:
+        serial_no = int(exif_data["Image BodySerialNumber"].values)
+    except (KeyError, ValueError):
+        raise ParsingError(
+            "Couldn't parse sensor version. Sensor might not be supported"
+        )
+
+    return serial_no
+
+
+@get_if_needed("exif_data", getter=get_exif_data, getter_args=["image_path"])
 def get_timestamp(image_path, exif_data=None, format_string="%Y:%m:%d %H:%M:%S"):
     """
     Get the time stamp of an image and parse it into a `datetime` object with the given format string.

--- a/imgparse/metadata.py
+++ b/imgparse/metadata.py
@@ -60,6 +60,7 @@ MAKE_AND_MODEL = Metadata(name="(Make, Model)", method=imgparse.get_make_and_mod
 DIMENSIONS = Metadata(name="Dimensions", method=imgparse.get_dimensions)
 GSD = Metadata(name="Gsd (m)", method=imgparse.get_gsd)
 FIRMWARE = Metadata(name="Firmware version", method=imgparse.get_firmware_version)
+SERIAL = Metadata(name="Serial Number", method=imgparse.get_serial_number)
 WAVELENGTH = Metadata(
     name="Central Wavelength, WavelengthFWHM", method=imgparse.get_wavelength_data
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imgparse"
-version = "1.17.2"
+version = "1.18.0"
 description = "Python image-metadata-parser utilities"
 authors = []
 

--- a/tests/test_imgparse.py
+++ b/tests/test_imgparse.py
@@ -396,6 +396,21 @@ def test_get_version_sentera(sentera_image_data):
     assert version == (0, 22, 3)
 
 
+def test_get_serial_no_sentera(sentera_6x_image_data):
+    serial_no = imgparse.get_serial_number(sentera_6x_image_data[0])
+    assert serial_no == 1
+
+
+def test_get_serial_non_numeric(sentera_65r_image_data):
+    with pytest.raises(ParsingError):
+        serial_no = imgparse.get_serial_number(sentera_65r_image_data[0])
+
+
+def test_get_serial_does_not_exist(sentera_quad_image_data):
+    with pytest.raises(ParsingError):
+        serial_no = imgparse.get_serial_number(sentera_quad_image_data[0])
+
+
 def test_bad_version(dji_image_data):
     exif_data = deepcopy(dji_image_data[1])
     exif_data["Image Software"].values = "Bad Version"


### PR DESCRIPTION
# Parse Serial No. from Exif
## What?
- Parse the Exif `BodySerialNumber` tag as an integer serial number.
## Why?
- WeedScout cares about characteristics of individual sensors being flown for specific corrections

## PR Checklist
- [x] Merged latest master
- [x] Updated version number
- [x] Version numbers match between package ``_version.py`` and *pyproject.toml*
## Breaking Changes
None.