### PR TITLE
Support for DJI ILS and Irradiance.  Fix for DJI CaptureUUID tag.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: image-parsing
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.8
   # dev dependencies
   - sphinx
   - sphinx_rtd_theme

--- a/imgparse/__init__.py
+++ b/imgparse/__init__.py
@@ -34,6 +34,7 @@ from imgparse.imgparse import (
     get_unique_id,
     get_wavelength_data,
     parse_session_alt,
+    get_irradiance,
 )
 from imgparse.metadata import get_metadata
 
@@ -68,4 +69,5 @@ __all__ = [
     "TerrainAPIError",
     "get_lens_model",
     "get_unique_id",
+    "get_irradiance",
 ]

--- a/imgparse/__init__.py
+++ b/imgparse/__init__.py
@@ -22,6 +22,7 @@ from imgparse.imgparse import (
     get_gsd,
     get_home_point,
     get_ils,
+    get_irradiance,
     get_lat_lon,
     get_lens_model,
     get_make_and_model,
@@ -34,7 +35,6 @@ from imgparse.imgparse import (
     get_unique_id,
     get_wavelength_data,
     parse_session_alt,
-    get_irradiance,
 )
 from imgparse.metadata import get_metadata
 

--- a/imgparse/_version.py
+++ b/imgparse/_version.py
@@ -1,3 +1,3 @@
 """Defines package version.  Parsed by setup.py and imported by __init__.py."""
 
-__version__ = "1.18.1"
+__version__ = "1.18.2"

--- a/imgparse/imgparse.py
+++ b/imgparse/imgparse.py
@@ -720,12 +720,12 @@ def get_ils(image_path, exif_data=None, xmp_data=None):
 @get_if_needed("xmp_data", getter=get_xmp_data, getter_args=["image_path"])
 def get_irradiance(image_path, exif_data=None, xmp_data=None):
     """
-    Get the ILS value of an image captured by a sensor with an ILS module.
+    Get the Irradiance value of an image captured by a sensor with an DLS module.
 
     :param image_path: the full path to the image
     :param exif_data: used internally for memoization. Not necessary to supply.
     :param xmp_data: used internally for memoization. Not necessary to supply.
-    :return: **ils** - ILS value of image, as a floating point number
+    :return: **irradiance** - Irradiance value of image, as a floating point number
     :raises: ParsingError
     """
     try:

--- a/imgparse/imgparse.py
+++ b/imgparse/imgparse.py
@@ -840,7 +840,9 @@ def get_unique_id(image_path, xmp_data=None):
             logger.warning(
                 "Couldn't determine unique id. Parsing image ID from file name."
             )
-            return os.path.basename(image_path).split(".")[0]
+            img_name_split = os.path.basename(image_path).split("_")
+            return "_".join(img_name_split[0:3])
+
     # These field names were changed in a 6x firmware update
     try:
         # Firmware version >=2.1.0

--- a/imgparse/imgparse.py
+++ b/imgparse/imgparse.py
@@ -714,7 +714,7 @@ def get_ils(image_path, exif_data=None, xmp_data=None):
             return parse_seq(xmp_data[xmp_tags.ILS], float)
     except KeyError:
         raise ParsingError("Couldn't parse ILS value. Sensor might not be supported")
-    
+
 
 @get_if_needed("exif_data", getter=get_exif_data, getter_args=["image_path"])
 @get_if_needed("xmp_data", getter=get_xmp_data, getter_args=["image_path"])
@@ -736,7 +736,9 @@ def get_irradiance(image_path, exif_data=None, xmp_data=None):
         else:
             return parse_seq(xmp_data[xmp_tags.IRRADIANCE], float)
     except KeyError:
-        raise ParsingError("Couldn't parse IRRADIANCE value. Sensor might not be supported")
+        raise ParsingError(
+            "Couldn't parse IRRADIANCE value. Sensor might not be supported"
+        )
 
 
 @get_if_needed("exif_data", getter=get_exif_data, getter_args=["image_path"])

--- a/imgparse/imgparse.py
+++ b/imgparse/imgparse.py
@@ -709,7 +709,7 @@ def get_ils(image_path, exif_data=None, xmp_data=None):
         make, model = get_make_and_model(image_path, exif_data)
         xmp_tags = xmp.get_tags(make)
         if make == "DJI":
-            return float(xmp_data[xmp_tags.ILS])
+            return [float(xmp_data[xmp_tags.ILS])]
         else:
             return parse_seq(xmp_data[xmp_tags.ILS], float)
     except KeyError:

--- a/imgparse/imgparse.py
+++ b/imgparse/imgparse.py
@@ -711,6 +711,26 @@ def get_ils(image_path, exif_data=None, xmp_data=None):
         return parse_seq(xmp_data[xmp_tags.ILS], float)
     except KeyError:
         raise ParsingError("Couldn't parse ILS value. Sensor might not be supported")
+    
+
+@get_if_needed("exif_data", getter=get_exif_data, getter_args=["image_path"])
+@get_if_needed("xmp_data", getter=get_xmp_data, getter_args=["image_path"])
+def get_irradiance(image_path, exif_data=None, xmp_data=None):
+    """
+    Get the ILS value of an image captured by a sensor with an ILS module.
+
+    :param image_path: the full path to the image
+    :param exif_data: used internally for memoization. Not necessary to supply.
+    :param xmp_data: used internally for memoization. Not necessary to supply.
+    :return: **ils** - ILS value of image, as a floating point number
+    :raises: ParsingError
+    """
+    try:
+        make, model = get_make_and_model(image_path, exif_data)
+        xmp_tags = xmp.get_tags(make)
+        return parse_seq(xmp_data[xmp_tags.IRRADIANCE], float)
+    except KeyError:
+        raise ParsingError("Couldn't parse IRRADIANCE value. Sensor might not be supported")
 
 
 @get_if_needed("exif_data", getter=get_exif_data, getter_args=["image_path"])

--- a/imgparse/imgparse.py
+++ b/imgparse/imgparse.py
@@ -708,7 +708,10 @@ def get_ils(image_path, exif_data=None, xmp_data=None):
     try:
         make, model = get_make_and_model(image_path, exif_data)
         xmp_tags = xmp.get_tags(make)
-        return parse_seq(xmp_data[xmp_tags.ILS], float)
+        if make == "DJI":
+            return float(xmp_data[xmp_tags.ILS])
+        else:
+            return parse_seq(xmp_data[xmp_tags.ILS], float)
     except KeyError:
         raise ParsingError("Couldn't parse ILS value. Sensor might not be supported")
     
@@ -728,7 +731,10 @@ def get_irradiance(image_path, exif_data=None, xmp_data=None):
     try:
         make, model = get_make_and_model(image_path, exif_data)
         xmp_tags = xmp.get_tags(make)
-        return parse_seq(xmp_data[xmp_tags.IRRADIANCE], float)
+        if make == "DJI":
+            return float(xmp_data[xmp_tags.IRRADIANCE])
+        else:
+            return parse_seq(xmp_data[xmp_tags.IRRADIANCE], float)
     except KeyError:
         raise ParsingError("Couldn't parse IRRADIANCE value. Sensor might not be supported")
 

--- a/imgparse/imgparse.py
+++ b/imgparse/imgparse.py
@@ -831,6 +831,16 @@ def get_unique_id(image_path, xmp_data=None):
     :param xmp_data: used internally for memoization. Not necessary to supply.
     :return: unique image id in the form <session_id>_<image_id>
     """
+    # DJI CaptureUUID
+    make, model = get_make_and_model(image_path)
+    if make == "DJI":
+        try:
+            return str(xmp_data["drone-dji:CaptureUUID"])
+        except KeyError:
+            logger.warning(
+                "Couldn't determine unique id. Parsing image ID from file name."
+            )
+            return os.path.basename(image_path).split(".")[0]
     # These field names were changed in a 6x firmware update
     try:
         # Firmware version >=2.1.0

--- a/imgparse/xmp.py
+++ b/imgparse/xmp.py
@@ -54,6 +54,8 @@ class DJITags(SensorTags):
     WAVELENGTH_CENTRAL = "Camera:CentralWavelength"
     WAVELENGTH_FWHM = "Camera:WavelengthFWHM"
     BANDNAME = "Camera:BandName"
+    ILS = "Camera:SunSensor"
+    IRRADIANCE = "Camera:Irradiance"
 
 
 class MicaSenseTags(SensorTags):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imgparse"
-version = "1.18.1"
+version = "1.18.2"
 description = "Python image-metadata-parser utilities"
 authors = []
 


### PR DESCRIPTION
# Support for DJI ILS and Irradiance
## What?
- New function for getting Irradiance value from an image
- Add ILS to DJI xmp data options.
- Update get_unique_id function to support DJI sensors.
## Why?
- Allow `py-radiometric-corrections` to support ILS corrections.
- Fix for bug in get_unique_id function for M3M and likely P4P-MS(not sure, not really used for corrections anyways).

## PR Checklist
- [ ] Merged latest master
- [x] Updated version number
- [x] Version numbers match between package ``_version.py`` and *pyproject.toml*
## Breaking Changes
- CS ILS variability check?  CS throws an error for missing ILS values in M3M data, it should not error anymore with this version of image-metadata-parser.  We should test this to confirm no issues.
