### PR TITLE
Fix version

### DIFF
--- a/imgparse/_version.py
+++ b/imgparse/_version.py
@@ -1,9 +1,5 @@
 """Defines package version."""
 
 import importlib.metadata
-import os
 
-if os.environ.get("VERSION"):
-    __version__ = os.environ.get("VERSION")
-else:
-    __version__ = importlib.metadata.version("imgparse")
+__version__ = importlib.metadata.version("imgparse")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,9 @@ name = "imgparse"
 version = "2.0.1"
 description = "Python image-metadata-parser utilities"
 authors = []
+include = [
+    "imgparse/py.typed"
+]
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imgparse"
-version = "2.0.0"
+version = "2.0.1"
 description = "Python image-metadata-parser utilities"
 authors = []
 


### PR DESCRIPTION
# Fix version
## What?
Don't grab library version from VERSION environment variable
## Why?
This logic was intended for services to set their version in Docker images, not for libraries. I copied this version logic without thinking, and it will cause all our libraries to appear to have the same version when this envvar is set
## PR Checklist
- [x] Merged latest master
- [x] Updated version number
## Breaking Changes
No
