### PR TITLE
Hotfix: Dewarp Flag & Python 3.10

### DIFF
--- a/imgparse/parser.py
+++ b/imgparse/parser.py
@@ -555,7 +555,7 @@ class MetadataParser:
     def dewarp_flag(self) -> bool:
         """Get the dewarp flag of the image."""
         try:
-            return bool(self.xmp_data[self.xmp_tags.DEWARP_FLAG])
+            return bool(int(self.xmp_data[self.xmp_tags.DEWARP_FLAG]))
         except KeyError:
             raise ParsingError(
                 "Couldn't parse dewarp flag. Sensor might not be supported"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imgparse"
-version = "2.0.2"
+version = "2.0.3"
 description = "Python image-metadata-parser utilities"
 authors = []
 include = [
@@ -8,7 +8,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 exifread = "*"
 click = "*"
 xmltodict = "*"


### PR DESCRIPTION
# Hotfix: Dewarp Flag & Python 3.10
## What?
- Fix type in dewarp flag function.
- Require python 3.10+
## Why?
- The dewarp flag is read in as a string not a 0/1 integer so a 0 is still returning as true.
- There is some formatting in the function descriptions that is not allowed in python 3.9 so it is not usable in 3.9 environments.
## PR Checklist
- [ ] Merged latest master
- [ ] Updated version number
## Breaking Changes
