### PR TITLE
Fix for GPS accuracy function to handle fractions

### DIFF
--- a/imgparse/parser.py
+++ b/imgparse/parser.py
@@ -606,9 +606,9 @@ class MetadataParser:
     def gps_accuracy(self) -> tuple[float, float, float]:
         """Get the GPS accuracy values in meters for x, y, and z."""
         try:
-            x_acc = float(self.xmp_data[self.xmp_tags.X_ACCURACY_M])
-            y_acc = float(self.xmp_data[self.xmp_tags.Y_ACCURACY_M])
-            z_acc = float(self.xmp_data[self.xmp_tags.Z_ACCURACY_M])
+            x_acc = eval(self.xmp_data[self.xmp_tags.X_ACCURACY_M])
+            y_acc = eval(self.xmp_data[self.xmp_tags.Y_ACCURACY_M])
+            z_acc = eval(self.xmp_data[self.xmp_tags.Z_ACCURACY_M])
             return x_acc, y_acc, z_acc
         except KeyError:
             raise ParsingError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imgparse"
-version = "2.0.9"
+version = "2.0.10"
 description = "Python image-metadata-parser utilities"
 authors = []
 include = [


### PR DESCRIPTION
# Fix for GPS accuracy function to handle fractions
## What?
- Use eval function to convert values to a float to handle fraction values found in Sentera D4k images.
## Why?
## PR Checklist
- [ ] Merged latest master
- [ ] Updated version number
## Breaking Changes
