### PR TITLE
Use `fractions` for fraction parsing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,6 @@ repos:
       additional_dependencies: [
           'flake8-docstrings',
           'flake8-builtins',
-          'flake8-logging-format',
           'flake8-rst-docstrings',
           'pygments',
           'pep8-naming'

--- a/imgparse/parser.py
+++ b/imgparse/parser.py
@@ -42,9 +42,9 @@ class MetadataParser:
             if image_path[:5] == "s3://":
                 self.image_path = S3Path.from_uri(image_path)
             else:
-                self.image_path = Path(image_path)
+                self.image_path = Path(image_path)  # type: ignore
         else:
-            self.image_path = image_path
+            self.image_path = image_path  # type: ignore
 
         self.s3_role = s3_role
 

--- a/imgparse/parser.py
+++ b/imgparse/parser.py
@@ -3,6 +3,7 @@
 import logging
 import re
 from datetime import datetime, timedelta
+from fractions import Fraction
 from pathlib import Path
 from typing import Any
 
@@ -606,11 +607,26 @@ class MetadataParser:
     def gps_accuracy(self) -> tuple[float, float, float]:
         """Get the GPS accuracy values in meters for x, y, and z."""
         try:
-            x_acc = eval(self.xmp_data[self.xmp_tags.X_ACCURACY_M])
-            y_acc = eval(self.xmp_data[self.xmp_tags.Y_ACCURACY_M])
-            z_acc = eval(self.xmp_data[self.xmp_tags.Z_ACCURACY_M])
+            gps_accuracy_decimal_pattern = re.compile(r"[+-]?\d+(?:\.\d+)?")
+            gps_accuracy_fraction_pattern = re.compile(r"[+-]?\d+\s*/\s*[+-]?\d+")
+
+            def _parse_accuracy(value: Any) -> float:
+                """Parse a GPS accuracy value represented as a decimal or fraction."""
+                value_str = str(value).strip()
+
+                if gps_accuracy_decimal_pattern.fullmatch(value_str):
+                    return float(value_str)
+
+                if gps_accuracy_fraction_pattern.fullmatch(value_str):
+                    return float(Fraction(value_str.replace(" ", "")))
+
+                raise ValueError(f"Unsupported GPS accuracy format: {value_str}")
+
+            x_acc = _parse_accuracy(self.xmp_data[self.xmp_tags.X_ACCURACY_M])
+            y_acc = _parse_accuracy(self.xmp_data[self.xmp_tags.Y_ACCURACY_M])
+            z_acc = _parse_accuracy(self.xmp_data[self.xmp_tags.Z_ACCURACY_M])
             return x_acc, y_acc, z_acc
-        except KeyError:
+        except (KeyError, ValueError, ZeroDivisionError):
             raise ParsingError(
                 "Couldn't parse GPS accuracy. Sensor might not be supported"
             )

--- a/imgparse/parser.py
+++ b/imgparse/parser.py
@@ -42,9 +42,9 @@ class MetadataParser:
             if image_path[:5] == "s3://":
                 self.image_path = S3Path.from_uri(image_path)
             else:
-                self.image_path = Path(image_path)  # type: ignore
+                self.image_path = Path(image_path)
         else:
-            self.image_path = image_path  # type: ignore
+            self.image_path = image_path
 
         self.s3_role = s3_role
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imgparse"
-version = "2.0.10"
+version = "2.0.11"
 description = "Python image-metadata-parser utilities"
 authors = []
 include = [

--- a/tests/test_imgparse.py
+++ b/tests/test_imgparse.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from io import BytesIO
 from pathlib import Path
-from typing import Any
+from typing import Any, no_type_check
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -606,6 +606,7 @@ def test_get_capture_id(
         sentera_parser.capture_id()
 
 
+@no_type_check
 def test_get_gps_accuracy_parses_decimal_fraction_and_numeric(
     bad_dji_parser: MetadataParser,
 ) -> None:
@@ -622,6 +623,7 @@ def test_get_gps_accuracy_parses_decimal_fraction_and_numeric(
     assert [x_acc, y_acc, z_acc] == pytest.approx([1.5, -1.5, 2.0], abs=1e-09)
 
 
+@no_type_check
 def test_get_gps_accuracy_bad_format_raises(bad_dji_parser: MetadataParser) -> None:
     bad_dji_parser._xmp_data.update(
         {
@@ -635,6 +637,7 @@ def test_get_gps_accuracy_bad_format_raises(bad_dji_parser: MetadataParser) -> N
         bad_dji_parser.gps_accuracy()
 
 
+@no_type_check
 def test_get_gps_accuracy_zero_denominator_raises(
     bad_dji_parser: MetadataParser,
 ) -> None:

--- a/tests/test_imgparse.py
+++ b/tests/test_imgparse.py
@@ -606,6 +606,50 @@ def test_get_capture_id(
         sentera_parser.capture_id()
 
 
+def test_get_gps_accuracy_parses_decimal_fraction_and_numeric(
+    bad_dji_parser: MetadataParser,
+) -> None:
+    bad_dji_parser._xmp_data.update(
+        {
+            bad_dji_parser.xmp_tags.X_ACCURACY_M: "1.5",
+            bad_dji_parser.xmp_tags.Y_ACCURACY_M: "-3 / 2",
+            bad_dji_parser.xmp_tags.Z_ACCURACY_M: 2,
+        }
+    )
+
+    x_acc, y_acc, z_acc = bad_dji_parser.gps_accuracy()
+
+    assert [x_acc, y_acc, z_acc] == pytest.approx([1.5, -1.5, 2.0], abs=1e-09)
+
+
+def test_get_gps_accuracy_bad_format_raises(bad_dji_parser: MetadataParser) -> None:
+    bad_dji_parser._xmp_data.update(
+        {
+            bad_dji_parser.xmp_tags.X_ACCURACY_M: "1.5m",
+            bad_dji_parser.xmp_tags.Y_ACCURACY_M: "1.0",
+            bad_dji_parser.xmp_tags.Z_ACCURACY_M: "2.0",
+        }
+    )
+
+    with pytest.raises(ParsingError):
+        bad_dji_parser.gps_accuracy()
+
+
+def test_get_gps_accuracy_zero_denominator_raises(
+    bad_dji_parser: MetadataParser,
+) -> None:
+    bad_dji_parser._xmp_data.update(
+        {
+            bad_dji_parser.xmp_tags.X_ACCURACY_M: "1/0",
+            bad_dji_parser.xmp_tags.Y_ACCURACY_M: "1.0",
+            bad_dji_parser.xmp_tags.Z_ACCURACY_M: "2.0",
+        }
+    )
+
+    with pytest.raises(ParsingError):
+        bad_dji_parser.gps_accuracy()
+
+
 @patch("imgparse.util.s3_resource")
 @patch("imgparse.util.exifread.process_file")
 def test_get_make_and_model_s3(


### PR DESCRIPTION
# Improved fraction parsing

## What?
- Uses `fractions` builtin to parse fractions in `GPSAccuracy*` tags

## PR Checklist
- [x] Merged latest master
- [x] Updated version number

## Breaking Changes
None.