### PR TITLE
Add m4e pixel patch

### DIFF
--- a/imgparse/parser.py
+++ b/imgparse/parser.py
@@ -206,6 +206,19 @@ class MetadataParser:
                 "Couldn't parse pixel pitch. Sensor might not be supported"
             )
 
+        # Some models (e.g. Matrice 4E) have multiple cameras that share the same
+        # model string; the pixel pitch is stored per image width to identify the lens.
+        if isinstance(pixel_pitch, dict):
+            width = self.dimensions().width
+            try:
+                pixel_pitch = pixel_pitch[width]
+            except KeyError:
+                raise ParsingError(
+                    f"Pixel pitch for {self.model()} at image width {width} isn't "
+                    "supported yet. Only the Wide camera is currently supported for "
+                    "this sensor."
+                )
+
         return pixel_pitch
 
     def calibrated_focal_length(self) -> tuple[float, bool]:

--- a/imgparse/parser.py
+++ b/imgparse/parser.py
@@ -214,9 +214,7 @@ class MetadataParser:
                 pixel_pitch = pixel_pitch[width]
             except KeyError:
                 raise ParsingError(
-                    f"Pixel pitch for {self.model()} at image width {width} isn't "
-                    "supported yet. Only the Wide camera is currently supported for "
-                    "this sensor."
+                    f"Pixel pitch for {self.model()} at image width {width} is not supported."
                 )
 
         return pixel_pitch

--- a/imgparse/pixel_pitches.py
+++ b/imgparse/pixel_pitches.py
@@ -24,6 +24,7 @@ DJI_PIXEL_PITCH = {
     "ZenmuseP1": 4.27e-06,  # Zemmuse P1 (M300) (24mm, 35mm, 50mm)
     "FC3170": 8e-07,  # Mavic Air 2
     "M3E": 3.28e-06,  # Mavic 3 Enterprise
+    "M4E": 3.28e-06,  # Matrice 4E (wide camera: 4/3" CMOS, 5280x3956)
     "FC6360": 3.0e-06,  # Phantom 4 Multispectral
     "FC6310R": 2.41e-06,  # Phatom 4 Pro RTK
     "M3M": 3.28e-06,  # Mavic 3 Multispectral

--- a/imgparse/pixel_pitches.py
+++ b/imgparse/pixel_pitches.py
@@ -7,9 +7,17 @@ To add a new supported camera make, create a new dictionary of camera model/pixe
 to ``PIXEL_PITCHES``, indexed by camera make.
 
 To add a new supported camera model, simply append a new model/pixel pitch pair to the existing camera make dictionary.
+
+Some DJI models (e.g. the Matrice 4E) expose multiple cameras that all report the same ``Image Model``. For those,
+the value is a dictionary keyed by image width (in pixels), which uniquely identifies the lens/sensor. See
+``MetadataParser.pixel_pitch_meters`` for how these are resolved.
 """
 
-DJI_PIXEL_PITCH = {
+# A pixel pitch is either a single value (meters) or, for sensors whose cameras
+# share an ``Image Model``, a mapping of image width (pixels) -> pixel pitch.
+PixelPitch = float | dict[int, float]
+
+DJI_PIXEL_PITCH: dict[str, PixelPitch] = {
     "FC6310": 2.41e-06,  # Phantom 4 Pro
     "FC6310S": 2.41e-06,  # Phantom 4 Pro V2
     "FC220": 1.55e-06,  # Phantom 2 Vision
@@ -24,24 +32,26 @@ DJI_PIXEL_PITCH = {
     "ZenmuseP1": 4.27e-06,  # Zemmuse P1 (M300) (24mm, 35mm, 50mm)
     "FC3170": 8e-07,  # Mavic Air 2
     "M3E": 3.28e-06,  # Mavic 3 Enterprise
-    "M4E": 3.28e-06,  # Matrice 4E (wide camera: 4/3" CMOS, 5280x3956)
+    "M4E": {
+        5280: 3.28e-06,  # Wide camera (4/3" CMOS, 5280x3956)
+    },
     "FC6360": 3.0e-06,  # Phantom 4 Multispectral
     "FC6310R": 2.41e-06,  # Phatom 4 Pro RTK
     "M3M": 3.28e-06,  # Mavic 3 Multispectral
 }
 
-HASSELBLAD_PIXEL_PITCH = {
+HASSELBLAD_PIXEL_PITCH: dict[str, PixelPitch] = {
     "L1D-20c": 2.4e-06,  # Mavic 2 Pro
     "L2D-20c": 3.28e-06,  # Mavic 3 Classic
 }
 
-SONY_PIXEL_PITCH = {
+SONY_PIXEL_PITCH: dict[str, PixelPitch] = {
     "DSC-RX1RM2": 4.5e-06,  # Sony Cyber-shot RX1R II (42.4MP)
     "DSC-RX100M2": 2.41e-06,  # Sony Cyber-shot DSC-RX100 II (20.2MP)
     "ILCE-7RM4A": 3.76e-06,  # Sony A7R IV (60.2MP)
 }
 
-PIXEL_PITCHES = {
+PIXEL_PITCHES: dict[str, dict[str, PixelPitch]] = {
     "DJI": DJI_PIXEL_PITCH,
     "Hasselblad": HASSELBLAD_PIXEL_PITCH,
     "SONY": SONY_PIXEL_PITCH,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "imgparse"
-version = "2.0.12"
+version = "2.0.13"
 description = "Python image-metadata-parser utilities"
 authors = []
 include = [

--- a/tests/test_imgparse.py
+++ b/tests/test_imgparse.py
@@ -19,6 +19,14 @@ class Tag:
         self.values = values
 
 
+class Ratio:
+    """Minimal stand-in for exifread's Ratio (has ``num`` / ``den``)."""
+
+    def __init__(self, num: int, den: int):
+        self.num = num
+        self.den = den
+
+
 @pytest.fixture
 def bad_data_parser() -> MetadataParser:
     parser = MetadataParser(base_path / "BAD_IMG.jpg")
@@ -75,6 +83,34 @@ def sentera_parser() -> MetadataParser:
 @pytest.fixture
 def dji_parser() -> MetadataParser:
     return MetadataParser(base_path / "DJI_normal.JPG")
+
+
+@pytest.fixture
+def m4e_wide_parser() -> MetadataParser:
+    parser = MetadataParser(base_path / "M4E_wide.JPG")
+    parser._exif_data = {
+        "Image Make": Tag("DJI"),
+        "Image Model": Tag("M4E"),
+        "EXIF FocalLength": Tag([Ratio(1229, 100)]),
+        "EXIF ExifImageWidth": Tag([5280]),
+        "EXIF ExifImageLength": Tag([3956]),
+    }
+    parser._xmp_data = {}
+    return parser
+
+
+@pytest.fixture
+def m4e_tele_parser() -> MetadataParser:
+    parser = MetadataParser(base_path / "M4E_tele.JPG")
+    parser._exif_data = {
+        "Image Make": Tag("DJI"),
+        "Image Model": Tag("M4E"),
+        "EXIF FocalLength": Tag([Ratio(1229, 100)]),
+        "EXIF ExifImageWidth": Tag([8064]),
+        "EXIF ExifImageLength": Tag([6048]),
+    }
+    parser._xmp_data = {}
+    return parser
 
 
 @pytest.fixture
@@ -142,6 +178,20 @@ def test_get_camera_params_dji(dji_parser: MetadataParser) -> None:
     assert focal1 == 0.0088
     assert pitch1 == 2.41e-06
     assert focal_pixels == pytest.approx(3651.4523, abs=1e-04)
+
+
+def test_get_camera_params_m4e_wide(m4e_wide_parser: MetadataParser) -> None:
+    assert m4e_wide_parser.pixel_pitch_meters() == 3.28e-06
+    assert m4e_wide_parser.focal_length_pixels() == pytest.approx(3746.9512, abs=1e-04)
+
+
+def test_get_camera_params_m4e_non_wide_unsupported(
+    m4e_tele_parser: MetadataParser,
+) -> None:
+    # Non-Wide M4E lenses (e.g. width 8064) aren't supported yet and must raise
+    # rather than silently reuse the Wide pixel pitch.
+    with pytest.raises(ParsingError):
+        m4e_tele_parser.pixel_pitch_meters()
 
 
 def test_get_camera_params_sentera(sentera_parser: MetadataParser) -> None:


### PR DESCRIPTION
# M4E Pixel Pitch — Derivation

## Value added
`DJI_PIXEL_PITCH["M4E"] = {5280: 3.28e-06}` (meters), keyed by image width, for
the **Wide (mapping) camera** only.

## Derivation
From the DJI Matrice 4E [spec sheet](https://enterprise.dji.com/matrice-4-series/specs) (Wide camera):
- **Image Sensor:** 4/3-inch CMOS (nominal active width ≈ 17.3 mm)
- **Max Photo Size:** 5280 × 3956 px

```
pixel pitch = 17.3 mm / 5280 px ≈ 3.28 µm = 3.28e-06 m
```

The already-supported **M3E** (Mavic 3 Enterprise) shares the identical sensor
(4/3" CMOS, 20 MP) and image size (5280 × 3956) and is also coded as `3.28e-06`.

## Caveat / scope
This value applies **only to the Wide camera**. The M4E's Medium Tele (1/1.3"
48 MP, width 8064) and Telephoto (1/1.5" 48 MP, width 8192) lenses report the
same `Image Model` (`M4E`) but have different pixel pitches. Because we have no
sample images for those lenses, they are intentionally **not supported**:
`pixel_pitch_meters()` resolves the M4E entry by image width and raises a
`ParsingError` for any non-Wide width. When sample data is available, add the
`8064` / `8192` width keys to `DJI_PIXEL_PITCH["M4E"]` to enable them.

Lenses can also be distinguished via `FocalLengthIn35mmFilm` (24 = Wide,
70 = Medium Tele, 168 = Telephoto).

## Why?
- currently `parser.focal_length_pixels()` fails with `KeyError: 'M4E'`

## PR Checklist
- [x] Merged latest master
- [x] Updated version number
## Breaking Changes
